### PR TITLE
Added object-assign as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   "license": "MIT",
   "dependencies": {
     "debounce": "^1.0.0",
+    "object-assign": "^2.0.0",
     "react": "^0.12.0"
   },
   "devDependencies": {
     "browserify": "^6.1.0",
     "http-server": "^0.7.2",
-    "object-assign": "^2.0.0",
     "reactify": "^0.16.0",
     "watchify": "^2.0.0"
   },


### PR DESCRIPTION
Moved `object-assign` from being a devDependency to be dependency.
I couldn't build this with browserify without doing this...
