### PR TITLE
fix proptypes warning

### DIFF
--- a/json-inspector.js
+++ b/json-inspector.js
@@ -14,7 +14,7 @@ var noop = require('./lib/noop');
 module.exports = React.createClass({
     propTypes: {
         data: React.PropTypes.object.isRequired,
-        search: React.PropTypes.component,
+        search: React.PropTypes.element,
         onClick: React.PropTypes.func,
         validateQuery: React.PropTypes.func,
         isExpanded: React.PropTypes.func,


### PR DESCRIPTION
Fixes a warning in react.

`Warning: ReactClass: prop type`search`is invalid; it must be a function, usually from React.PropTypes.`
