### PR TITLE
handle boolean type in search property

### DIFF
--- a/json-inspector.js
+++ b/json-inspector.js
@@ -18,7 +18,10 @@ module.exports = React.createClass({
             React.PropTypes.array.isRequired,
         ]),
         // For now it expects a factory function, not element.
-        search: React.PropTypes.func,
+        search: React.PropTypes.oneOfType([
+            React.PropTypes.func.isRequired,
+            React.PropTypes.bool.isRequired,
+        ]),
         onClick: React.PropTypes.func,
         validateQuery: React.PropTypes.func,
         isExpanded: React.PropTypes.func,


### PR DESCRIPTION
Otherwise react prompts warning when 'search=false' property is passed.

Obsoletes #13, if @Lapple will decide that.
