### PR TITLE
Fixed highlight to support case insensitive search option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.compiled.js
+.idea

--- a/json-inspector.js
+++ b/json-inspector.js
@@ -86,7 +86,10 @@ module.exports = React.createClass({
                         getOriginal: this.getOriginal,
                         query: (
                             isQueryValid ?
-                                s.query :
+                                new RegExp(
+                                        s.query,
+                                        (p.filterOptions.ignoreCase ? 'i' : '')
+                                ) :
                                 null
                         ),
                         label: 'root',

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -12,17 +12,19 @@ module.exports = React.createClass({
         return p.highlight !== this.props.highlight;
     },
     render: function() {
-        var p = this.props;
+        var p = this.props,
+            highlightStart = p.string.search(p.highlight);
 
-        if (!p.highlight || p.string.indexOf(p.highlight) === -1) {
+        if (!p.highlight || highlightStart === -1) {
             return span(null, p.string);
         }
-
+        var highlightLength = p.highlight.source.length,
+            highlightString = p.string.substr(highlightStart, highlightLength);
         return span(null,
             p.string.split(p.highlight).map(function(part, index) {
                 return span({ key: index },
                     index > 0 ?
-                        span({ className: 'json-inspector__hl' }, p.highlight) :
+                        span({ className: 'json-inspector__hl' }, highlightString) :
                         null,
                     part);
             }));


### PR DESCRIPTION
Highlight is not working correctly when searching in case insensitve mode. I fixed it by passing a search regex to the nodes instead of a search string.
