### PR TITLE
Add search enhancements, showOriginal flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Defaults to built-in search bar. Pass `false` to disable search.
 
 Optional parameters for search (toolbar). Must be an object.
 
-- `debounceTime`, wait time (ms) between search field `onChange` events before actually performing search. This can help provide a better user experience when searching larger data sets. Defaults to `300`.
+- `debounceTime`, wait time (ms) between search field `onChange` events before actually performing search. This can help provide a better user experience when searching larger data sets. Defaults to `0`.
 
 #### props.query
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ The class name to be added to the root component element.
 Search bar component that accepts `onChange`, `data` and `query` properties.
 Defaults to built-in search bar. Pass `false` to disable search.
 
+#### props.searchOptions
+
+Optional parameters for search (toolbar). Must be an object.
+
+- `debounceTime`, wait time (ms) between search field `onChange` events before actually performing search. This can help provide a better user experience when searching larger data sets. Defaults to `300`.
+
 #### props.query
 
 Optional initial search query, defaults to an empty string.
@@ -87,4 +93,9 @@ on initial render. Receives two arguments: `keypath` and `value`. Defaults to
 
 Optional parameters for filterer (search). Must be an object.
 
+- `cacheResults`, Set to `false` to disable the filterer cache. This can sometimes provide performance enhancements with larger data sets. Defaults to `true`.
 - `ignoreCase`, Set to `true` to enable case insensitivity in search. Defaults to `false`.
+
+#### props.verboseShowOriginal
+
+Set to `true` for full `showOriginal` expansion of children containing search term. Defaults to `false`.

--- a/json-inspector.js
+++ b/json-inspector.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var createReactClass = require('create-react-class');
 var PropTypes = require('prop-types');
+var debounce = require('debounce');
 
 var h = React.createElement;
 var Leaf = require('./lib/leaf');
@@ -19,21 +20,33 @@ module.exports = createReactClass({
             PropTypes.func,
             PropTypes.bool
         ]),
+        searchOptions: PropTypes.shape({
+            debounceTime: PropTypes.number
+        }),
         onClick: PropTypes.func,
         validateQuery: PropTypes.func,
         isExpanded: PropTypes.func,
-        filterOptions: PropTypes.object,
-        query: PropTypes.string
+        filterOptions: PropTypes.shape({
+            cacheResults: PropTypes.bool,
+            ignoreCase: PropTypes.bool
+        }),
+        query: PropTypes.string,
+        verboseShowOriginal: PropTypes.bool
     },
-
     getDefaultProps: function() {
         return {
             data: null,
             search: SearchBar,
+            searchOptions: {
+                debounceTime: 300
+            },
             className: '',
             id: 'json-' + Date.now(),
             onClick: noop,
-            filterOptions: {},
+            filterOptions: {
+                cacheResults: true,
+                ignoreCase: false
+            },
             validateQuery: function(query) {
                 return query.length >= 2;
             },
@@ -46,7 +59,8 @@ module.exports = createReactClass({
              */
             isExpanded: function(keypath, value) {
                 return false;
-            }
+            },
+            verboseShowOriginal: false
         };
     },
     getInitialState: function() {
@@ -95,7 +109,8 @@ module.exports = createReactClass({
                         label: 'root',
                         root: true,
                         isExpanded: p.isExpanded,
-                        interactiveLabel: p.interactiveLabel
+                        interactiveLabel: p.interactiveLabel,
+                        verboseShowOriginal: p.verboseShowOriginal
                     })
             )
         );
@@ -106,7 +121,7 @@ module.exports = createReactClass({
         if (search) {
             return h('div', { className: 'json-inspector__toolbar' },
                 h(search, {
-                    onChange: this.search,
+                    onChange: debounce(this.search, this.props.searchOptions.debounceTime),
                     data: this.props.data,
                     query: this.state.query
                 })

--- a/json-inspector.js
+++ b/json-inspector.js
@@ -38,7 +38,7 @@ module.exports = createReactClass({
             data: null,
             search: SearchBar,
             searchOptions: {
-                debounceTime: 300
+                debounceTime: 0
             },
             className: '',
             id: 'json-' + Date.now(),

--- a/lib/filterer.js
+++ b/lib/filterer.js
@@ -5,10 +5,15 @@ var isPrimitive = require('./is-primitive');
 var isEmpty = require('./is-empty');
 
 module.exports = function(data, options) {
-    options || (options = {});
+    options || (options = { cacheResults: true });
+
     var cache = {};
 
     return function(query) {
+        if (!options.cacheResults) {
+           return find(data, query, options);
+        }
+
         var subquery;
 
         if (!cache[query]) {

--- a/lib/leaf.js
+++ b/lib/leaf.js
@@ -75,6 +75,8 @@ var Leaf = createReactClass({
             return Object.keys(data).map(function(key) {
                 var value = data[key];
 
+                var shouldGetOriginal = !this.state.original || (p.verboseShowOriginal ? p.query : false);
+
                 return h(Leaf, {
                     data: value,
                     label: key,
@@ -82,7 +84,7 @@ var Leaf = createReactClass({
                     onClick: p.onClick,
                     id: p.id,
                     query: p.query,
-                    getOriginal: this.state.original ? null : p.getOriginal,
+                    getOriginal: shouldGetOriginal ? p.getOriginal : null,
                     key: getLeafKey(key, value),
                     isExpanded: p.isExpanded,
                     interactiveLabel: p.interactiveLabel

--- a/lib/leaf.js
+++ b/lib/leaf.js
@@ -87,7 +87,8 @@ var Leaf = createReactClass({
                     getOriginal: shouldGetOriginal ? p.getOriginal : null,
                     key: getLeafKey(key, value),
                     isExpanded: p.isExpanded,
-                    interactiveLabel: p.interactiveLabel
+                    interactiveLabel: p.interactiveLabel,
+                    verboseShowOriginal: p.verboseShowOriginal
                 });
             }, this);
         }

--- a/lib/search-bar.js
+++ b/lib/search-bar.js
@@ -1,4 +1,3 @@
-var debounce = require('debounce');
 var React = require('react');
 var createReactClass = require('create-react-class');
 
@@ -16,7 +15,6 @@ module.exports = createReactClass({
             className: 'json-inspector__search',
             type: 'search',
             placeholder: 'Search',
-            value: this.props.query,
             onChange: this.onChange
         });
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-json-inspector",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "React JSON inspector component",
   "main": "json-inspector.js",
   "author": {


### PR DESCRIPTION
Brought debounce back, which was removed a while back (https://github.com/Lapple/react-json-inspector/commit/a80422cf60935d38de7420d84d002c6fd73d6d6f#diff-6d51238a910fee4ddc7c6ef645a4b996). Debounce will now work with custom search bar's `onChange` handler as well as the default `SearchBar` component. (`searchOptions.debounceTime`)

Added the option to turn caching off, which actually brings a huge performance increase with searching larger data sets. (`filterOptions.cacheResults`)

Added the option to expand all children which are both ancestors to a child containing a matching search term and descendants of the element being expanded. Without this option turned on, clicking the "expand" button (i.e. `showOriginal`) of a grand-ancestor of a matched child would result in the immediate child of the grand-ancestor being expanded but not the matched child itself. This option will cascade down and expand all children until reaching the matched child. (`verboseShowOriginal`)