### PR TITLE
Mute deprecated function warnings with React > 16.9

### DIFF
--- a/json-inspector.js
+++ b/json-inspector.js
@@ -133,10 +133,10 @@ module.exports = createReactClass({
             query: query
         });
     },
-    componentWillMount: function() {
+    UNSAFE_componentWillMount: function() {
         this.createFilterer(this.props.data, this.props.filterOptions);
     },
-    componentWillReceiveProps: function(p) {
+    UNSAFE_componentWillReceiveProps: function(p) {
         this.createFilterer(p.data, p.filterOptions);
 
         var isReceivingNewQuery = (

--- a/lib/leaf.js
+++ b/lib/leaf.js
@@ -121,7 +121,7 @@ var Leaf = createReactClass({
 
         return null;
     },
-    componentWillReceiveProps: function(p) {
+    UNSAFE_componentWillReceiveProps: function(p) {
         if (p.query) {
             this.setState({
                 expanded: !contains(p.label, p.query)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "watchify": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^15.0.0"
+    "react": "^16.3.0"
   },
   "keywords": [
     "react-component"


### PR DESCRIPTION
`componentWillReceiveProps` and `componentWillMount` are deprecated and
should be replaced. This commit simply mutes the warnings in the browser
console.

One of the muted warning:
```
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Leaf
```

![Screenshot from 2020-02-12 17-22-56](https://user-images.githubusercontent.com/6225979/74355008-847a0100-4dbc-11ea-8086-a1e745bb9d1e.png)

See https://fb.me/react-unsafe-component-lifecycles

:warning: This is a breaking change since it bumps required react version to 16.3.0 (when the `UNSAFE__*` methods have been added). 

---

If you're still there @Lapple, I can open a second pull request to replace these lifecycle methods.